### PR TITLE
chore: update invite link to vanity invite

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ py -3 -m pip install -U disnake[discord]
 
 - [Documentation](https://docs.disnake.dev/en/latest)
 - [disnake GitHub](https://github.com/DisnakeDev/disnake)
-- [disnake Discord](https://discord.gg/gJDbCw8aQy)
+- [disnake Discord](https://discord.gg/disnake)


### PR DESCRIPTION
## Summary

Discord recently verified our server, so without concern of losing our vanity, we are now safe to update all invites to https://discord.gg/disnake
