### PR TITLE
chore: deprecate/archive package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+<p align="center">
+    <h3>⚠️⚠️⚠️ This package is deprecated and is no longer being maintained. ⚠️⚠️⚠️</h3>
+    Please migrate your project to use https://pypi.org/project/disnake directly.
+</p>
+
+<br/>
+<br/>
+
+---
+
+Original Readme:
+
 # This package is a shim
 
 This module allows to use [disnake](https://github.com/DisnakeDev/disnake) using `discord` namespace. This is not an independent library.

--- a/discord/__init__.py
+++ b/discord/__init__.py
@@ -9,6 +9,17 @@ A basic wrapper for the Discord API.
 
 """
 
+##### DEPRECATED #####
+import warnings
+warnings.warn(
+    "The discord-disnake compatibility shim is deprecated and is no longer being updated. Please migrate your project to use https://pypi.org/project/disnake directly.",
+    UserWarning,
+    stacklevel=2,
+)
+######################
+
+
+
 __title__ = "disnake"
 __author__ = "Rapptz, EQUENOS"
 __license__ = "MIT"

--- a/discord/__init__.py
+++ b/discord/__init__.py
@@ -16,6 +16,7 @@ warnings.warn(
     UserWarning,
     stacklevel=2,
 )
+del warnings
 ######################
 
 

--- a/discord/__init__.py
+++ b/discord/__init__.py
@@ -24,7 +24,7 @@ __title__ = "disnake"
 __author__ = "Rapptz, EQUENOS"
 __license__ = "MIT"
 __copyright__ = "Copyright 2015-present Rapptz, 2021-present EQUENOS"
-__version__ = "2.3.0"
+__version__ = "2.3.0.2.post0"
 
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     install_requires=requirements,
     python_requires=">=3.8.0",
     classifiers=[
-        "Development Status :: 5 - Production/Stable",
+        "Development Status :: 7 - Inactive",
         "License :: OSI Approved :: MIT License",
         "Intended Audience :: Developers",
         "Natural Language :: English",


### PR DESCRIPTION
Resolves #6.
The package hasn't been updated in more than two years, and is only compatible with disnake v2.3 (and below). I don't think anyone plans to continue maintaining this, much less after such a long pause.

There's no standard process of deprecating a package on pypi, so emitting a warning on import and adding a line to the README is pretty much all we can do, besides yanking all published package versions.
Once a `2.3.0.2.post0` with these changes is released, this repo can be archived.